### PR TITLE
Add <Context> path attribute as a parameter for jira class

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ If the jira service is managed outside of puppet the stop_jira paramater can be 
 
 Defaults to {}, See examples on how to use.
 
+#####`$contextpath = ""`
+
+Defaults to an empty string (""). Will add a path to the Tomcat Server Context.
+
 ####Tomcat parameters####
 
 #####`$tomcatPort`
@@ -363,6 +367,7 @@ jira::proxy:
   scheme:    'https'
   proxyName: 'jira.example.co.za'
   proxyPort: '443'
+jira::contextpath: '/jira'
 ```
 
 Reverse proxy can be configured as a hash as part of the JIRA resource

--- a/jira.yaml
+++ b/jira.yaml
@@ -100,3 +100,5 @@ jira::proxy:
   scheme:    'https'
   proxyName: 'www.exmaple.co.za'
   proxyPort: '443'
+# Configure path attribute for the <Context>
+jira::contextpath: '/jira'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,12 +104,15 @@ class jira (
   
   # Reverse https proxy
   $proxy = {},
+  # Context path (usualy used in combination with a reverse proxy)
+  $contextpath = '',
 
 ) inherits jira::params {
 
-  if $jira::db != 'postgresql' and $jira::db != 'mysql' {
-    fail('jira db parameter must be postgresql or mysql')
-  }
+  # Parameter validations
+  validate_re($db, ['^postgresql','^mysql'], 'The JIRA $db parameter must be "postgresql" or "mysql".')
+  validate_hash($proxy)
+  validate_re($contextpath, ['^$', '^/.*'])
 
   if $::jira_version {
     # If the running version of JIRA is less than the expected version of JIRA

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -59,6 +59,15 @@ describe 'jira' do
       it { should contain_file('/home/jira/dbconfig.xml')
         .with_content(/<url>my custom dburl<\/url>/) }
     end
+    context 'tomcat context path' do
+      let(:params) {{
+        :version => '6.3.4a',
+        :javahome => '/opt/java',
+        :contextpath => '/jira',
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+        .with_content(/<Context path=\"\/jira\" docBase=\"\${catalina.home}\/atlassian-jira\" reloadable=\"false\" useHttpOnly=\"true\">/) }
+    end
 
   end
 end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -119,7 +119,7 @@
         <Engine name="Catalina" defaultHost="localhost">
             <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
 
-                <Context path="" docBase="${catalina.home}/atlassian-jira" reloadable="false" useHttpOnly="true">
+                <Context path="<% @contextpath %>" docBase="${catalina.home}/atlassian-jira" reloadable="false" useHttpOnly="true">
 
 
                     <!--

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -119,7 +119,7 @@
         <Engine name="Catalina" defaultHost="localhost">
             <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
 
-                <Context path="<% @contextpath %>" docBase="${catalina.home}/atlassian-jira" reloadable="false" useHttpOnly="true">
+                <Context path="<%= @contextpath %>" docBase="${catalina.home}/atlassian-jira" reloadable="false" useHttpOnly="true">
 
 
                     <!--


### PR DESCRIPTION
This PR will add template code to be able to add a context path for the JIRA Tomcat instance. 

I need this in companion with my reverse proxy, as I have a context path in my apache in which I add the reverse proxy configuration.

I added some validations in init.pp, too. (For $contextpath, $proxy and $db).