### PR TITLE
Add oracle to validate and correct jdbc syntax

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class jira (
 ) inherits jira::params {
 
   # Parameter validations
-  validate_re($db, ['^postgresql','^mysql','^sqlserver'], 'The JIRA $db parameter must be "postgresql", "mysql", "sqlserver".')
+  validate_re($db, ['^postgresql','^mysql','^sqlserver','^oracle'], 'The JIRA $db parameter must be "postgresql", "mysql", "sqlserver".')
   validate_hash($proxy)
   validate_re($contextpath, ['^$', '^/.*'])
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@ class jira (
     $dburl_real = $db ? {
       'postgresql' => "jdbc:${db}://${dbserver}:${dbport}/${dbname}",
       'mysql'      => "jdbc:${db}://${dbserver}:${dbport}/${dbname}?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=storage_engine=InnoDB",
-      'oracle'     => "jdbc::${db}:thin:@${dbserver}:${dbport}:${dbname}",
+      'oracle'     => "jdbc:${db}:thin:@${dbserver}:${dbport}:${dbname}",
       'sqlserver'  => "jdbc:jtds:${db}://${dbserver}:${dbport}/${dbname}"
     }
   }


### PR DESCRIPTION
Adds Oracle to the list of databases that can pass validation, and correct connection string for Oracle databases.