### PR TITLE
Add a notify and subscribe options to the jira service

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ Manage the JIRA service, defaults to 'running'
 
 Defaults to 'true'
 
+#####`$service_subscribe`
+
+Restart the jira service in response to this subscription
+
+#####`$service_notify`
+
+Notify other puppet resources to refresh after the jira service
+
 #####`$stop_jira`
 If the jira service is managed outside of puppet the stop_jira parameter can be used to shut down jira for upgrades. Defaults to 'service jira stop && sleep 15'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,8 @@ class jira (
   $service_manage = true,
   $service_ensure = running,
   $service_enable = true,
+  $service_notify = undef,
+  $service_subscribe = undef,
   # Command to stop jira in preparation to updgrade. This is configurable
   # incase the jira service is managed outside of puppet. eg: using the
   # puppetlabs-corosync module: 'crm resource stop jira && sleep 15'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,8 @@ class jira::service(
   $service_manage        = $jira::service_manage,
   $service_ensure        = $jira::service_ensure,
   $service_enable        = $jira::service_enable,
+  $service_notify        = $jira::service_notify,
+  $service_subscribe     = $jira::service_subscribe,
   $service_file_location = $jira::params::service_file_location,
   $service_file_template = $jira::params::service_file_template,
   $service_lockfile      = $jira::params::service_lockfile,
@@ -46,9 +48,11 @@ class jira::service(
     }
 
     service { 'jira':
-      ensure  => $service_ensure,
-      enable  => $service_enable,
-      require => File[$service_file_location],
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      require   => File[$service_file_location],
+      notify    => $service_notify,
+      subscribe => $service_subscribe,
     }
   }
 }

--- a/spec/classes/jira_service_spec.rb
+++ b/spec/classes/jira_service_spec.rb
@@ -48,10 +48,13 @@ describe 'jira' do
         :javahome       => '/opt/java',
         :service_ensure => 'stopped',
         :service_enable => false,
+        :service_subscribe => 'Package[jdk]',
       }}
       it { should contain_service('jira').with({
         'ensure' => 'stopped',
         'enable' => 'false',
+        'notify' => nil,
+        'subscribe' => 'Package[jdk]',
       })}
     end
     context 'RedHat/CentOS 7 systemd init script' do


### PR DESCRIPTION
Use case is when something like JDK is updated underneath jira, you'd want the service to restart, with:
```puppet
subscribe => Package['jdk']
```
I tested separately, services work fine with something like:
 ```puppet 
notify => undef
```
in the service definition.