### PR TITLE
Add MS SQL Server tests

### DIFF
--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -25,6 +25,19 @@ describe 'jira' do
       it { should contain_file('/home/jira/dbconfig.xml')
         .with_content(/<url>jdbc:mysql:\/\/localhost:5432\/jira\?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=storage_engine=InnoDB<\/url>/) }
     end
+    context 'sqlserver params' do
+      let(:params) {{
+        :version  => '6.3.4a',
+        :javahome => '/opt/java',
+        :db       => 'sqlserver',
+        :dbport   => '1433',
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh')}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh')}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')}
+      it { should contain_file('/home/jira/dbconfig.xml')
+        .with_content(/<url>jdbc:jtds:sqlserver:\/\/localhost:1433\/jira<\/url>/) }
+    end
     context 'custom dburl' do
       let(:params) {{
         :version  => '6.3.4a',


### PR DESCRIPTION
Added tests for Microsoft SQL Server, per Issue #54.

I based it off the existing tests but was unable to run the test suite via rake due a protocol error unrelated to what I added (tried it without my modification).  This was the first time I've written or run spec tests so I think it is related to my setup, not necessarily the tests.

Also my apologies, I wasn't sure how to connect this to the existing issue.