### PR TITLE
Adding contextpath support to facter jira custom fact.

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -18,6 +18,7 @@ class jira::facts(
   $ensure        = 'present',
   $port          = $jira::tomcatPort,
   $uri           = '127.0.0.1',
+  $contextpath   = $jira::contextpath,
   $json_packages = $jira::params::json_packages,
 ) inherits jira::params {
 

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -27,5 +27,14 @@ describe 'jira' do
             .with_content(regexp_oss)
         end
     end
+
+    context 'tomcat context path' do
+      let(:params) {{
+        :javahome => '/opt/java',
+        :contextpath => '/jira',
+      }}
+      it { should contain_file(external_fact_file)
+        .with_content(/  url = 'http:\/\/127.0.0.1:8080\/jira/) }
+    end
   end
 end

--- a/templates/facts.rb.erb
+++ b/templates/facts.rb.erb
@@ -13,7 +13,7 @@
 require 'json'
 require 'open-uri'
 begin
-  url = 'http://<%= @uri %>:<%= @port %>/rest/api/2/serverInfo'
+  url = 'http://<%= @uri %>:<%= @port %><%= @contextpath %>/rest/api/2/serverInfo'
   info = open(url, &:read)
 rescue
   exit 0


### PR DESCRIPTION
I had trouble updating my recent installation of jira as the fact could not be executed (error 404 without the context).

This adds the proper contextpath to the url.

Includes a proper rspec test in classes/jira_facts_spec.rb.