### PR TITLE
Provide capability to set Tomcat's bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ Defaults to an empty string (""). Will add a path to the Tomcat Server Context.
 
 ####Tomcat parameters####
 
+#####`$tomcatAddress`
+
+IP address to listen on. Defaults to all addresses.
+
 #####`$tomcatPort`
 
 Port to listen on, defaults to 8080,

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -17,7 +17,10 @@
 class jira::facts(
   $ensure        = 'present',
   $port          = $jira::tomcatPort,
-  $uri           = '127.0.0.1',
+  $uri           = $jira::tomcatAddress ? {
+    undef   => '127.0.0.1',
+    default => $jira::tomcatAddress,
+  },
   $contextpath   = $jira::contextpath,
   $json_packages = $jira::params::json_packages,
 ) inherits jira::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class jira (
   $stop_jira = 'service jira stop && sleep 15',
 
   # Tomcat
+  $tomcatAddress = undef,
   $tomcatPort = 8080,
 
   # Tomcat Tunables

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -56,6 +56,16 @@ describe 'jira' do
       it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
         .with_content(/<Context path=\"\/jira\" docBase=\"\${catalina.home}\/atlassian-jira\" reloadable=\"false\" useHttpOnly=\"true\">/) }
     end
+    context 'customise tomcat connector' do
+      let(:params) {{
+        :version  => '6.3.4a',
+        :javahome => '/opt/java',
+        :tomcatPort => '9229',
+        :tomcatAddress => '127.0.0.1'
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+        .with_content(/<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"/m) }
+    end
 
   end
 end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -47,6 +47,9 @@
     <Service name="Catalina">
 
         <Connector port="<%= scope.lookupvar('jira::tomcatPort') %>"
+                   <%- unless scope.lookupvar('jira::tomcatAddress') == :undef -%>
+                   address="<%= scope.lookupvar('jira::tomcatAddress') %>"
+                   <%- end -%>
 
                    maxThreads="<%= scope.lookupvar('jira::tomcatMaxThreads') %>"
                    minSpareThreads="25"


### PR DESCRIPTION
Add a new parameter, jira::tomcatAddress, which is passed through to the Tomcat's Connector configuration. Useful for environments where Jira is deployed behind a reverse proxy such as Nginx.

The parameter defaults to undef, and if left unset, the Connector configuration will not include the address= parameter (i.e. existing installations will be unchanged)

A new rspec test has been provided to test this functionality.
