### PR TITLE
Fix server.xml template

### DIFF
--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -62,12 +62,22 @@ describe 'jira::config' do
             :version  => '6.3.4a',
             :javahome => '/opt/java',
             :tomcatPort => '9229',
+          }}
+          it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+            .with_content(/<Connector port=\"9229\"\s+maxThreads=/m) }
+        end
+
+        context 'customise tomcat connector with a binding address' do
+          let(:params) {{
+            :version  => '6.3.4a',
+            :javahome => '/opt/java',
+            :tomcatPort => '9229',
             :tomcatAddress => '127.0.0.1'
           }}
           it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
-            .with_content(/<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"/m) }
+            .with_content(/<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"\s+maxThreads=/m) }
         end
-
+        
         context 'tomcat context path' do
           let(:params) {{
             :version => '6.3.4a',

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -47,7 +47,7 @@
     <Service name="Catalina">
 
         <Connector port="<%= @tomcatPort %>"
-                   <%- unless @tomcatAddress == :undef -%>
+                   <%- if @tomcatAddress -%>
                    address="<%= @tomcatAddress %>"
                    <%- end -%>
                    maxThreads="<%= @tomcatMaxThreads %>"


### PR DESCRIPTION
It had been generating an invalid `address` config of the `<Connector>`. Adding a spec test for it.

Fixes my comment in #67 .