### PR TITLE
Adding rspec tests for AJP connector and fixing template code for AJP

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,7 @@ class jira (
   validate_hash($proxy)
   validate_re($contextpath, ['^$', '^/.*'])
   validate_hash($resources)
+  validate_hash($ajp)
 
   if $::jira_version {
     # If the running version of JIRA is less than the expected version of JIRA
@@ -150,6 +151,19 @@ class jira (
       'mysql'      => "jdbc:${db}://${dbserver}:${dbport}/${dbname}?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=storage_engine=InnoDB",
       'oracle'     => "jdbc:${db}:thin:@${dbserver}:${dbport}:${dbname}",
       'sqlserver'  => "jdbc:jtds:${db}://${dbserver}:${dbport}/${dbname}"
+    }
+  }
+
+  if ! empty($ajp) {
+    if ! has_key($ajp, 'port') {
+      fail('You need to specify a valid port for the AJP connector.')
+    } else {
+      validate_re($ajp['port'], '^\d+$')
+    }
+    if ! has_key($ajp, 'protocol') {
+      fail('You need to specify a valid protocol for the AJP connector.')
+    } else {
+      validate_re($ajp['protocol'], ['^AJP/1.3$', '^org.apache.coyote.ajp'])
     }
   }
 

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -125,6 +125,33 @@ describe 'jira::config' do
           }
         end
 
+        context 'ajp proxy' do
+          context 'with valid config including protocol AJP/1.3' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'port' => '8009',
+                'protocol' => 'AJP/1.3',
+              },
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+              .with_content(/<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP\/1\.3"\s+\/>/) }
+          end
+          context 'with valid config including protocol org.apache.coyote.ajp.AjpNioProtocol' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'port' => '8009',
+                'protocol' => 'org.apache.coyote.ajp.AjpNioProtocol',
+              },
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+              .with_content(/<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "org\.apache\.coyote\.ajp\.AjpNioProtocol"\s+\/>/) }
+          end
+        end
+
         context 'context resources' do
           let(:params) {{
             :version => '6.3.4a',

--- a/spec/classes/jira_init_spec.rb
+++ b/spec/classes/jira_init_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper.rb'
+
+describe 'jira' do
+describe 'jira::init' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+        context 'ajp proxy' do
+          context 'without port' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'protocol' => 'AJP/1.3',
+              },
+            }}
+            it { should raise_error(Puppet::Error, /You need to specify a valid port for the AJP connector\./) } 
+          end
+          context 'with invalid port' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'port' => '80zeronine',
+                'protocol' => 'AJP/1.3',
+              },
+            }}
+            it { should raise_error(Puppet::Error, /validate_re\(\): "80zeronine" does not match/) } 
+          end
+          context 'without protocol' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'port' => '8009',
+              },
+            }}
+            it { should raise_error(Puppet::Error, /You need to specify a valid protocol for the AJP connector\./) } 
+          end
+          context 'with invalid protocol' do
+            let(:params) {{
+              :version => '6.3.4a',
+              :javahome => '/opt/java',
+              :ajp => {
+                'port' => '8009',
+                'protocol' => 'AJP',
+              },
+            }}
+            it { should raise_error(Puppet::Error, /validate_re\(\): "AJP" does not match/) } 
+          end
+        end
+      end
+    end
+  end
+end
+end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -114,13 +114,13 @@
          ====================================================================================
         -->
 
-<% if @ajp -%>
-   <Connector enableLookups="false" URIEncoding="UTF-8"
-<%   @ajp.sort.each do |key,value| -%>
- <%= key %> = <%= "\'#{value}\'" %>
+<% if @ajp and ! @ajp.empty? -%>
+        <Connector enableLookups="false" URIEncoding="UTF-8"
+<%   @ajp.sort.each do |key, value| -%>
+                   <%= key %> = <%= "\"#{value}\"" %>
 <%   end -%>
+        />
 <% end -%>
-/>
   
         <Engine name="Catalina" defaultHost="localhost">
             <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">


### PR DESCRIPTION
Fixes #55.
* This includes validation and error messages for the AJP settings hash.
* Adds spec testing for the template and for the validation.